### PR TITLE
Use clang builtin in place of rdtsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build/*
 bin/
 tmp/
 breakpoints
+
+.DS_Store

--- a/src/engine/cpp/asset.cpp
+++ b/src/engine/cpp/asset.cpp
@@ -203,7 +203,11 @@ DeserializeMesh(native_file *File, world_chunk_file_header *Header, untextured_3
   Assert(NormalElementSize == (u32)sizeof(v3));
   ReadBytesIntoBuffer(File, NormalElementSize*TotalElements, (u8*)Result->Normals);
 
+  #ifdef __APPLE__
+  Result->Timestamp = __builtin_readcyclecounter();;
+  #else
   Result->Timestamp = __rdtsc();
+  #endif
 
   return Result;
 }

--- a/src/engine/cpp/entity.cpp
+++ b/src/engine/cpp/entity.cpp
@@ -1602,7 +1602,12 @@ RebuildWorldChunkMesh(thread_local_state *Thread, world_chunk *Chunk)
     }
   }
 
+  #ifdef __APPLE__
+  umm Timestamp = NewMesh ? NewMesh->Timestamp : __builtin_readcyclecounter();
+  #else
   umm Timestamp = NewMesh ? NewMesh->Timestamp : __rdtsc();
+  #endif
+
   auto Replaced = AtomicReplaceMesh(&Chunk->Meshes, MeshBit_Main, NewMesh, Timestamp);
   if (Replaced) { DeallocateMesh(&Replaced, &Thread->EngineResources->MeshFreelist, Thread->PermMemory); }
 }


### PR DESCRIPTION
The `RDTSC` instruction is only available on x86 processors. The clang builtin `__builtin_readcyclecounter()` should be used instead on other platforms. This will improve support for Apple Silicon devices.